### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+version: 2
+updates:
+  # Go backend dependencies
+  - package-ecosystem: "gomod"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Africa/Johannesburg"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    reviewers:
+      - "justanotherspy"
+
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Africa/Johannesburg"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    reviewers:
+      - "justanotherspy"
+    groups:
+      # Group Svelte-related updates together
+      svelte:
+        patterns:
+          - "svelte*"
+          - "@sveltejs/*"
+      # Group dev dependencies together
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Africa/Johannesburg"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    reviewers:
+      - "justanotherspy"


### PR DESCRIPTION
## Summary

Configures Dependabot to automatically check and create pull requests for dependency updates across the project:

- **Go backend:** Weekly checks on Mondays for go module updates (max 5 open PRs)
- **Frontend npm:** Weekly checks with intelligent grouping (Svelte packages, dev dependencies)
- **GitHub Actions:** Weekly checks for action updates

All updates are scheduled for 09:00 Africa/Johannesburg timezone to align with development workflow.

## Details

The configuration includes:
- Clear labeling system for easy categorization (dependencies, go, frontend, github-actions)
- Consistent commit prefix `chore(deps)` for standardized commit messages
- Automatic assignment to repository owner for review
- Smart grouping on frontend to batch related updates (Svelte ecosystem, dev dependencies)
- Rate limiting to prevent PR spam (5 open PRs max per category)

## Benefits

- Keeps dependencies current and secure automatically
- Reduces manual dependency management overhead
- Provides organized, labeled PRs for easy review
- Helps maintain project health with minimal manual intervention